### PR TITLE
modify DateTime/Follow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# copy
+.DS_Store

--- a/theme/peak/js/common/ui/Datalist.js
+++ b/theme/peak/js/common/ui/Datalist.js
@@ -255,7 +255,7 @@
             var customSuccess = params.data.success;
 
             this.callback.data = function() {
-                // 清除延时，避免妹子输入都请求
+                // 清除延时，避免每次输入都请求
                 clearTimeout(self.ajaxTimer);
 
                 // 有2个参数有内置，需要合并

--- a/theme/peak/js/common/ui/Follow.js
+++ b/theme/peak/js/common/ui/Follow.js
@@ -319,10 +319,10 @@
                 }
                 case 'left': {
                     tarL = triL - tarW;
-                    if (strFirst == '2') {
+                    if (strFirst == '1') {
                         tarT = triT;
-                    } else if (strFirst === '6') {
-                        tarT = triT - (tarW - triW) / 2;
+                    } else if (strFirst === '8') {
+                        tarT = triT - (tarH - triH) / 2;
                     } else {
                         tarT = triT - (tarH - triH);
                     }


### PR DESCRIPTION
[修改后的展示链接](https://codepen.io/despair-lj/pen/jorKZy)

# DateTime
1. 在 type 为 date/month/minute 并且有 min/max 的时候, 从 year/month 选择模块跳转到 month/day 模块的时候, 没有进行判断直接赋值, 导致可以选择出超过 min/max 的值
2. 在没有设置初始值, 并且在今天/本月/今年不处于可选择范围内, 会选择超过范围内的值. 并且在这状态下会出现看上去无法选择的状况, 要先去到月份/年份的选择才能进行正常的选择
3. 在 type 为 date-range, 上一个月份的日期不能用 1, 当 min 存在, 最前的月份会无法选择, 例如前一个月是 10 , 最小值为 10-14, 那么 前一个月份为 10-01. 永远是小于设定的最小月份导致无法到达最小的月份
4. 在 type 为 date 的时候, 从日期选择跳转到月份选择的时候, 月份选择不会显示那个月份被选择
5. 在选择年份的时候, 当前一次选择的年份为 2021 年的时候并且最小年份是 2014年, 按照原来的判断 2021 - 12 = 2009 < 2014 导致无法前进到选择 2014 年的界面.

# Follow
1. follow 的 position 为 '1-2'/'8-6'/'4-3' 的时候, 判断条件是为 right 的状态. 左居中的计算是错误的