### PR TITLE
优化类名显示 & 修正按钮元素的 aria-expanded 属性值

### DIFF
--- a/theme/pure/js/common/ui/Select.js
+++ b/theme/pure/js/common/ui/Select.js
@@ -237,7 +237,8 @@
                             }
                         }
                         // 下拉收起
-                        eleCombobox.classList.remove(ACTIVE);
+                        eleCombobox.classList.
+                        ACTIVE);
                         eleButton.setAttribute('aria-expanded', 'false');
                         // focus
                         eleButton.focus();
@@ -270,7 +271,8 @@
                     eleButton = eleCombobox.querySelector('.' + CL.add('button'))
 
                     if (eleCombobox.contains(target) == false) {
-                        eleCombobox.classList.remove(ACTIVE, REVERSE);
+                        eleCombobox.classList.remove(ACTIVE);
+                        eleCombobox.classList.remove(REVERSE);
                         // aria状态
                         eleButton.setAttribute('aria-expanded', 'false');
                     }

--- a/theme/pure/js/common/ui/Select.js
+++ b/theme/pure/js/common/ui/Select.js
@@ -263,9 +263,16 @@
                     // 识别此时的combobox
                     eleCombobox = document.querySelector(SELECT + '+.' + CL + '.' + ACTIVE);
 
-                    if (eleCombobox && eleCombobox.contains(target) == false) {
-                        eleCombobox.classList.remove(ACTIVE);
-                        eleCombobox.classList.remove(REVERSE);
+                    if (!eleCombobox) {
+                        return
+                    }
+                    
+                    eleButton = eleCombobox.querySelector('.' + CL.add('button'))
+
+                    if (eleCombobox.contains(target) == false) {
+                        eleCombobox.classList.remove(ACTIVE, REVERSE);
+                        // aria状态
+                        eleButton.setAttribute('aria-expanded', 'false');
                     }
                 });
 

--- a/theme/pure/js/common/ui/Select.js
+++ b/theme/pure/js/common/ui/Select.js
@@ -457,8 +457,11 @@
 
         // 列表内容的刷新
         eleDatalist.innerHTML = data.map(function (obj, index) {
-            var arrCl = [CL.add('datalist', 'li'), obj.className];
+            var arrCl = [CL.add('datalist', 'li')];
 
+            if (obj.className) {
+                arrCl.push(obj.className);
+            }
             if (obj[SELECTED]) {
                 arrCl.push(SELECTED);
             }

--- a/theme/pure/js/common/ui/Select.js
+++ b/theme/pure/js/common/ui/Select.js
@@ -237,8 +237,7 @@
                             }
                         }
                         // 下拉收起
-                        eleCombobox.classList.
-                        ACTIVE);
+                        eleCombobox.classList.remove(ACTIVE);
                         eleButton.setAttribute('aria-expanded', 'false');
                         // focus
                         eleButton.focus();


### PR DESCRIPTION
1. 优化类名显示 

如果 obj.className 值为空（''），因为还是数组里的有效元素，在 arrCl.join(' ') 的时候，类名中总会多出一个空格。

![image](https://user-images.githubusercontent.com/21121929/76695812-7589b580-66be-11ea-8997-3491a7d19b03.png)

2. 修正按钮元素的 aria-expanded 属性值

当点击按钮元素打开列表时，按钮元素的 aria-expanded 的值为 true。此时，再在外部点击鼠标，另下拉列表关闭，但没有对按钮元素的 aria-expanded 属性值做修正。

![GIF](https://user-images.githubusercontent.com/21121929/76696149-3a3db580-66c3-11ea-8a91-cf33361e4a86.gif)